### PR TITLE
feat: support dynamic "bucketName" for customer domain endpoint

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/cosn/CustomerDomainEndpointResolver.java
+++ b/src/main/java/org/apache/hadoop/fs/cosn/CustomerDomainEndpointResolver.java
@@ -29,9 +29,9 @@ public class CustomerDomainEndpointResolver implements EndpointBuilder {
     }
 
     @Override
-    public String buildGeneralApiEndpoint(String s) {
+    public String buildGeneralApiEndpoint(String bucketName) {
         if (this.endPoint != null) {
-            return this.endPoint;
+            return this.endPoint.replace("<bucketName>", bucketName);
         } else {
             log.error("Get customer domain is null");
         }


### PR DESCRIPTION
bucket names are commonly used as part of end point,  so adding a bucket name replacement holder may make customer domain endpoint more flexible