### PR TITLE
improve: add flush switch to create

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/CosNConfigKeys.java
+++ b/src/main/java/org/apache/hadoop/fs/CosNConfigKeys.java
@@ -179,7 +179,7 @@ public class CosNConfigKeys extends CommonConfigurationKeys {
 
 
     public static final String COSN_FLUSH_ENABLED = "fs.cosn.flush.enabled";
-    public static final boolean DEFAULT_COSN_FLUSH_ENABLED = true;
+    public static final boolean DEFAULT_COSN_FLUSH_ENABLED = false;
     public static final String COSN_MAPDISK_DELETEONEXIT_ENABLED = "fs.cosn.map_disk.delete_on_exit.enabled";
     public static final boolean DEFAULT_COSN_MAPDISK_DELETEONEXIT_ENABLED = true;
 

--- a/src/main/java/org/apache/hadoop/fs/CosNFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/CosNFileSystem.java
@@ -343,8 +343,8 @@ public class CosNFileSystem extends FileSystem {
 
         Path absolutePath = makeAbsolute(f);
         String key = pathToKey(absolutePath);
-        if (this.getConf().getBoolean(CosNConfigKeys.COSN_POSIX_EXTENSION_ENABLED,
-                CosNConfigKeys.DEFAULT_COSN_POSIX_EXTENSION_ENABLED)) {
+        if (this.getConf().getBoolean(CosNConfigKeys.COSN_FLUSH_ENABLED,
+            CosNConfigKeys.DEFAULT_COSN_FLUSH_ENABLED)) {
             // Need to support the synchronous flush.
             return new FSDataOutputStream(
                     new CosNExtendedFSDataOutputStream(this.getConf(), nativeStore, key,


### PR DESCRIPTION
允许使用fs.cosn.flush.enabled=true，使得create接口创建的流支持同步flush。