### PR TITLE
Support ByteBufferReadable interface in CosNFileSystem

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/CosNFSBufferedFSInputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/CosNFSBufferedFSInputStream.java
@@ -1,0 +1,28 @@
+package org.apache.hadoop.fs;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class CosNFSBufferedFSInputStream extends BufferedFSInputStream implements ByteBufferReadable {
+
+    public CosNFSBufferedFSInputStream(FSInputStream in, int size) {
+        super(in, size);
+    }
+
+    @Override
+    public int read(ByteBuffer byteBuffer) throws IOException {
+        final int bufSize = 1024;
+        byte[] buf = new byte[bufSize];
+        int totalRead = 0;
+        while (byteBuffer.hasRemaining()) {
+            int maxReadSize = Math.min(bufSize, byteBuffer.remaining());
+            int readLen = this.read(buf, 0, maxReadSize);
+            if (readLen <= 0) {
+                return totalRead == 0 ? -1 : totalRead;
+            }
+            byteBuffer.put(buf, 0, readLen);
+            totalRead += readLen;
+        }
+        return totalRead;
+    }
+}

--- a/src/main/java/org/apache/hadoop/fs/CosNFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/CosNFileSystem.java
@@ -900,7 +900,7 @@ public class CosNFileSystem extends FileSystem {
         LOG.debug("Opening '" + f + "' for reading");
         Path absolutePath = makeAbsolute(f);
         String key = pathToKey(absolutePath);
-        return new FSDataInputStream(new BufferedFSInputStream(
+        return new FSDataInputStream(new CosNFSBufferedFSInputStream(
                 new CosNFSInputStream(this.getConf(), nativeStore, statistics, key,
                         fileStatus.getLen(), this.boundedIOThreadPool),
                 bufferSize));


### PR DESCRIPTION
Support ByteBufferReadable interface in CosNFileSystem for eliminate UnsupportedOperationException