### PR TITLE
fix: Fix the resource release order of CosNFileSystem

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/CosFileSystem.java
+++ b/src/main/java/org/apache/hadoop/fs/CosFileSystem.java
@@ -55,7 +55,6 @@ public class CosFileSystem extends FileSystem {
     private boolean isPosixUseOFSRanger;
     private boolean isPosixImpl = false;
     private FileSystem actualImplFS = null;
-    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private URI uri;
     private Path workingDir;
@@ -707,10 +706,6 @@ public class CosFileSystem extends FileSystem {
     @Override
     public void close() throws IOException {
         LOG.info("begin to close cos file system");
-        if (this.closed.getAndSet(true)) {
-            // already closed
-            return;
-        }
         this.initialized = false;
         try {
             super.close();


### PR DESCRIPTION
修复 CosNFileSystem 的 close 顺序，需要先释放掉 IO 资源，然后才能调用 super.close 释放基类资源。 元数据类的资源需要最后释放。