### PR TITLE
fix: check tmp dir permission after automatically mkdir

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -2,7 +2,7 @@
 
 base_dir=$(cd `dirname $0`;pwd)
 cd ${base_dir}
-hadoop_version_array=("2.7.5" "2.8.5" "3.1.0" "3.2.2" "3.3.0")
+hadoop_version_array=("2.7.5" "2.8.5" "3.1.0" "3.2.2" "3.3.0" "3.4.0")
 
 origin_version=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec)
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 
 base_dir=$(cd `dirname $0`;pwd)
 
-hadoop_version_array=("2.7.5" "2.8.5" "3.1.0" "3.2.2" "3.3.0")
+hadoop_version_array=("2.7.5" "2.8.5" "3.1.0" "3.2.2" "3.3.0" "3.4.0")
 
 NORMAL="normal"
 INTER="inter"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.qcloud.cos</groupId>
     <artifactId>hadoop-cos</artifactId>
-    <version>8.3.15</version>
+    <version>8.3.16</version>
     <packaging>jar</packaging>
 
     <name>Apache Hadoop Tencent Cloud COS Support</name>

--- a/src/main/java/org/apache/hadoop/fs/CosNUtils.java
+++ b/src/main/java/org/apache/hadoop/fs/CosNUtils.java
@@ -334,12 +334,6 @@ public final class CosNUtils {
     public static boolean checkDirectoryRWPermissions(String directoryPath) {
         java.nio.file.Path path = Paths.get(directoryPath);
 
-        // check dir is existed
-        if (!java.nio.file.Files.exists(path)) {
-	        LOG.error("the directory {} is not exist", directoryPath);
-            return false;
-        }
-
         // check the input is a dir
         if (!java.nio.file.Files.isDirectory(path)) {
             LOG.error("the {} is not a directory", directoryPath);

--- a/src/main/java/org/apache/hadoop/fs/cosn/BufferPool.java
+++ b/src/main/java/org/apache/hadoop/fs/cosn/BufferPool.java
@@ -122,12 +122,6 @@ public final class BufferPool {
         } else if (this.bufferType == CosNBufferType.MAPPED_DISK) {
             String tmpDir = conf.get(CosNConfigKeys.COSN_TMP_DIR,
                     CosNConfigKeys.DEFAULT_TMP_DIR);
-            // Check whether you have read and write permissions for the directory during initialization
-            if (!CosNUtils.checkDirectoryRWPermissions(tmpDir)) {
-                String exceptionMsg = String.format("The tmp dir does not have read or write permissions." +
-                        "dir: %s", tmpDir);
-                throw new IllegalArgumentException(exceptionMsg);
-            }
             boolean deleteOnExit = conf.getBoolean(CosNConfigKeys.COSN_MAPDISK_DELETEONEXIT_ENABLED,
                     CosNConfigKeys.DEFAULT_COSN_MAPDISK_DELETEONEXIT_ENABLED);
             String[] tmpDirList = tmpDir.split(",");

--- a/src/main/java/org/apache/hadoop/fs/cosn/buffer/CosNMappedBufferFactory.java
+++ b/src/main/java/org/apache/hadoop/fs/cosn/buffer/CosNMappedBufferFactory.java
@@ -1,5 +1,6 @@
 package org.apache.hadoop.fs.cosn.buffer;
 
+import org.apache.hadoop.fs.CosNUtils;
 import org.apache.hadoop.fs.cosn.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +55,12 @@ public class CosNMappedBufferFactory implements CosNBufferFactory {
         } else {
             LOG.debug("buffer dir: {} already exists.",
                     file.getAbsolutePath());
+            // Check whether you have read and write permissions for the directory during initialization
+            if (!CosNUtils.checkDirectoryRWPermissions(tmpDir)) {
+                String exceptionMsg = String.format("The tmp dir does not have read or write permissions." +
+                        "dir: %s", tmpDir);
+                throw new IllegalArgumentException(exceptionMsg);
+            }
         }
 
         return file;


### PR DESCRIPTION
fix: check tmp dir permission after automatically mkdir