### PR TITLE
feature: finalize in DelegateToFileSystem to avoid NM oom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,14 @@
             <version>3.1.1193</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>0.8.6</version>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -275,6 +283,34 @@
                     <publishingServerId>central</publishingServerId>
                     <checksums>required</checksums>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pre-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>target/jacoco.exec</dataFile>
+                            <outputDirectory>target/site/jacoco</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.qcloud.cos</groupId>
     <artifactId>hadoop-cos</artifactId>
-    <version>8.3.28</version>
+    <version>8.3.29</version>
     <packaging>jar</packaging>
 
     <name>Apache Hadoop Tencent Cloud COS Support</name>

--- a/src/main/java/org/apache/hadoop/fs/CosN.java
+++ b/src/main/java/org/apache/hadoop/fs/CosN.java
@@ -16,4 +16,22 @@ public class CosN extends DelegateToFileSystem {
     public int getUriDefaultPort() {
         return -1;
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CosN{");
+        sb.append("URI =").append(fsImpl.getUri());
+        sb.append("; fsImpl=").append(fsImpl);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /**
+     * Close the file system; the FileContext API doesn't have an explicit close.
+     */
+    @Override
+    protected void finalize() throws Throwable {
+        fsImpl.close();
+        super.finalize();
+    }
 }


### PR DESCRIPTION
使用NameNode的FileContext，运行期间不会关闭文件系统，导致资源泄露，解决方案参考s3a，如下
https://github.com/apache/hadoop/pull/4966
https://issues.apache.org/jira/browse/HADOOP-18476