### PR TITLE
perf: use bulk copy for input stream reads

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/CosNFSInputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/CosNFSInputStream.java
@@ -465,22 +465,16 @@ public class CosNFSInputStream extends FSInputStream {
                 reopen(position);
             }
 
-            int bytes = 0;
             byte[] buffer = currentReadBuffer.getBuffer();
             Objects.requireNonNull(buffer);
-            for (int i = buffer.length - (int) partRemaining;
-                 i < buffer.length; i++) {
-                b[off + bytesRead] = buffer[i];
-                bytes++;
-                bytesRead++;
-                if (off + bytesRead >= len) {
-                    break;
-                }
-            }
+            int bytes = Math.min((int) this.partRemaining, len - bytesRead);
+            int bufferOffset = buffer.length - (int) this.partRemaining;
+            System.arraycopy(buffer, bufferOffset, b, off + bytesRead, bytes);
 
             if (bytes > 0) {
                 this.position += bytes;
                 this.partRemaining -= bytes;
+                bytesRead += bytes;
             } else if (this.partRemaining != 0) {
                 throw new IOException("Failed to read from stream. Remaining:" +
                         " " + this.partRemaining);


### PR DESCRIPTION
## Summary

- Replace the byte-by-byte copy loop in
  `CosNFSInputStream.read(byte[], int, int)` with `System.arraycopy`.
- Compute the copy length once per read-ahead buffer and update the stream
  position and remaining-byte counters after the bulk copy.
- Keep the change limited to the copy path; no read-ahead, retry, or COS
  request behavior is changed.

## Motivation

The previous implementation copied every byte in Java and updated counters
inside the inner loop. Large reads therefore paid per-byte loop overhead even
though both the source and destination were byte arrays.

## Performance

An in-memory benchmark repeatedly read an already-loaded 32 MiB CosN
read-ahead buffer. Each round copied 1.25 GiB:

| Implementation | Median time | Throughput |
| --- | ---: | ---: |
| Existing byte loop | 306.9 ms | 4.07 GiB/s |
| `System.arraycopy` | 38.1 ms | 32.8 GiB/s |

This is about an 8.1x improvement for the isolated memory-copy hot path.

I also ran five A/B rounds against a real 10 GiB COS object from an EMR node
over the intranet, using 32 readers, 128 CosN I/O threads, and an 8 MiB
read-ahead block:

| Implementation | Mean throughput |
| --- | ---: |
| Existing byte loop | 1246.5 MiB/s |
| `System.arraycopy` | 1252.4 MiB/s |

The approximately 0.5% difference is within run-to-run COS/network variance,
so this PR does not claim an end-to-end COS throughput improvement. Its
measurable benefit is lower CPU overhead in the local copy path.

## Tests

Executed the complete test set against a real COS bucket from an EMR node:

```text
Time: 73.908
OK (42 tests)
```

## Follow-up observations

The surrounding method has validation behavior that may deserve a separate,
correctness-focused change:

- It checks `len > b.length`, but not whether `off + len` exceeds the
  destination array.
- It returns early for `len == 0` before validating the destination array and
  offset.
- The old inner-loop condition used `off + bytesRead >= len`, mixing the
  destination offset with the requested byte count. The bulk-copy calculation
  no longer needs that condition.

Those behaviors are intentionally not changed here so that this PR remains a
small performance-only change.
